### PR TITLE
Challenge quest UI small fixes

### DIFF
--- a/Stable/Gunz/ZRuleQuestChallenge.cpp
+++ b/Stable/Gunz/ZRuleQuestChallenge.cpp
@@ -239,17 +239,20 @@ void ZRuleQuestChallenge::OnDraw(MDrawContext* pDC)
 		pBmNumLabel = (ZBmNumLabel*)ZApplication::GetGameInterface()->GetIDLResource()->FindWidget("CQ_RoundProgress");
 		if (pBmNumLabel)
 		{
-
-			sprintf(szText, "%d/%d", m_nCurrSector + 1, GetRoundMax());
-			pBmNumLabel->SetText(szText);
+			if (m_nCurrSector != GetRoundMax())
+			{
+				sprintf(szText, "%d/%d", m_nCurrSector + 1, GetRoundMax());
+				pBmNumLabel->SetText(szText);
+			}		
 		}
+
 		MPicture* pPicture = (MPicture*)ZApplication::GetGameInterface()->GetIDLResource()->FindWidget("CQ_FadeBG");
 		if (pPicture)
 		{
 			pPicture->Show(false);
 			if (ZGetGame()->GetMatch()->GetRoundState() == MMATCH_ROUNDSTATE_FINISH)
 			{
-				if (m_nCurrSector + 1 < GetRoundMax())
+				if (m_nCurrSector + 1 <= GetRoundMax())
 				{
 					pPicture->Show(true);
 				}


### PR DESCRIPTION
Round counter label checked to not exceed max rounds, and the background fade works on the last round now.

![roundwidget](https://user-images.githubusercontent.com/52647746/182835022-f1c5870c-4e16-4eab-86f4-1f9d6d90579f.png)

